### PR TITLE
Use Python 2.7.14, Alpine Linux and Locust 0.8.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM quay.io/wantedly/python:2.7.7
-MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
+FROM python:2.7.14-alpine
 
-RUN pip install locustio pyzmq
+RUN apk add --no-cache -U \
+      zeromq-dev
+
+COPY requirements.txt /
+
+RUN apk add --no-cache -U --virtual build-deps \
+      g++ \
+    && pip install -r /requirements.txt \
+    && apk del build-deps
+
 WORKDIR /test
 
 ENTRYPOINT ["locust"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+certifi==2017.7.27.1
+chardet==3.0.4
+click==6.7
+Flask==0.12.2
+gevent==1.2.2
+greenlet==0.4.12
+idna==2.6
+itsdangerous==0.24
+Jinja2==2.9.6
+locustio==0.8.1
+MarkupSafe==1.0
+msgpack-python==0.4.8
+pyzmq==16.0.3
+requests==2.18.4
+six==1.11.0
+urllib3==1.22
+Werkzeug==0.12.2


### PR DESCRIPTION
## WHY

We'd like to use the latest Locust.

## WHAT

- Upgrade Locust: -> 0.8.1
- Upgrade Python: 2.7.7 -> 2.7.14
- Use Alpine Linux 3.4.6
  - Reduce image size: **799MB -> 113MB**