### PR TITLE
Install python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Please see [the official site](https://github.com/ryotarai/infrataster/) or [Git
   - Alpine Linux 3.6
   - Python 3.6.3
   - Locust 0.8.1
+  - [python-dotenv](https://github.com/theskumar/python-dotenv) 0.7.1
 
 ## HOW TO USE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Jinja2==2.9.6
 locustio==0.8.1
 MarkupSafe==1.0
 msgpack-python==0.4.8
+python-dotenv==0.7.1
 pyzmq==16.0.3
 requests==2.18.4
 six==1.11.0


### PR DESCRIPTION
## WHY

We'd like to use `.env` to read key-values as environment variables.

## WHAT

Install [python-dotenv](https://github.com/theskumar/python-dotenv) in Docker image.