### PR TITLE
Bump requests from 2.18.4 to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ MarkupSafe==1.0
 msgpack-python==0.4.8
 python-dotenv==0.7.1
 pyzmq==16.0.3
-requests==2.18.4
+requests==2.20.0
 six==1.11.0
 urllib3==1.22
 Werkzeug==0.12.2


### PR DESCRIPTION
## Why

> CVE-2018-18074 More information
> moderate severity
> Vulnerable versions: <= 2.19.1
> Patched version: 2.20.0
> The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

## What

Update `requests` to 2.20.0