### PR TITLE
Bump flask from 0.12.2 to 0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
-Flask==0.12.2
+Flask==0.12.3
 gevent==1.2.2
 greenlet==0.4.12
 idna==2.6


### PR DESCRIPTION
## Why

> CVE-2018-1000656 More information
> moderate severity
> Vulnerable versions: < 0.12.3
> Patched version: 0.12.3
> The Pallets Project flask version Before 0.12.3 contains a CWE-20: Improper Input Validation vulnerability in flask that can result in Large amount of memory usage possibly leading to denial of service. This attack appear to be exploitable via Attacker provides JSON data in incorrect encoding. This vulnerability appears to have been fixed in 0.12.3.

## What

Bump flask from 0.12.2 to 0.12.3