### PR TITLE
Bump up urllib3 to 1.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python-dotenv==0.7.1
 pyzmq==16.0.3
 requests==2.20.0
 six==1.11.0
-urllib3==1.22
+urllib3==1.23
 Werkzeug==0.12.2


### PR DESCRIPTION
## WHY 
A vulnerability is found.

<img width="1077" alt="alerts_ _wantedly_dockerfile-locust" src="https://user-images.githubusercontent.com/2713881/50061303-38482680-01e2-11e9-8178-ef2299fd6e2c.png">

cf. https://github.com/wantedly/dockerfile-locust/network/alert/requirements.txt/urllib3/open

## WHAT
Upgrade urllib3 to 1.23.

