### PR TITLE
Bump up version of jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gevent==1.2.2
 greenlet==0.4.12
 idna==2.6
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10.1
 locustio==0.8.1
 MarkupSafe==1.0
 msgpack-python==0.4.8


### PR DESCRIPTION
## WHY 
A vulnerability is found.

<img width="1094" alt="Screen Shot 2019-04-15 at 11 14 02" src="https://user-images.githubusercontent.com/2713881/56103827-affb4780-5f6f-11e9-877f-276c35c5ff26.png">

cf. https://github.com/wantedly/dockerfile-locust/network/alert/requirements.txt/Jinja2/open

## WHAT
Upgrade jinja2 to 2.10.1.
