### PR TITLE
Bump urllib3 to 1.24.2 for vulnerability handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python-dotenv==0.7.1
 pyzmq==16.0.3
 requests==2.20.0
 six==1.11.0
-urllib3==1.23
+urllib3==1.24.2
 Werkzeug==0.12.2


### PR DESCRIPTION
urllib3 v1.23.x includes a potential vulnerability.

![Alerts_·_wantedly_dockerfile-locust](https://user-images.githubusercontent.com/7877005/56483698-7b0a6a00-6506-11e9-900a-1d69a94e539c.png)

cf. https://github.com/wantedly/dockerfile-locust/network/alert/requirements.txt/urllib3/open